### PR TITLE
Опечатка в ДЗ 3

### DIFF
--- a/hw-theory.tex
+++ b/hw-theory.tex
@@ -276,7 +276,7 @@ A identity (A x) { return x; }
 \item $A \rightarrow B \rightarrow A$
 \item $A \with B \rightarrow A \vee B$
 \item $(A \with (B \vee C)) \rightarrow ((A \with B) \vee (A \with C))$
-\item $(A \rightarrow C) \with (B \rightarrow C) \with A \vee B \rightarrow C$
+\item $(A \rightarrow C) \with (B \rightarrow C) \with (A \vee B) \rightarrow C$
 \item $(B \vee C \rightarrow A) \rightarrow (B \rightarrow A) \with (C \rightarrow A)$
 \item $(A \rightarrow B) \rightarrow (\neg B \rightarrow \neg A)$
 \item $((A \rightarrow B) \rightarrow C) \rightarrow (A \rightarrow (B \rightarrow C))$


### PR DESCRIPTION
добавил в задание 3.5.d скобки, без которых оно некорректно