### PR TITLE
Update lection-11.tex

### DIFF
--- a/lection-11.tex
+++ b/lection-11.tex
@@ -176,7 +176,7 @@ $$\mathcal{E} = \{ P(e), P(e'), P(e''), P(e'''), P(e''''), \neg P(e''''), \dots 
 $\{ P(e) \}$ & $\llbracket P(e) \rrbracket  = \text{И}$ & 2 варианта\\
 $\{ P(e), P(e') \}$ & $\llbracket P(e) \rrbracket = \llbracket P(e') \rrbracket  = \text{И}$ & 4 варианта\\
 \dots\\
-$\{ P(e), \dots, P(e''''), \neg P(e'''') \}$ & невыполнимо & 64 варианта
+$\{ P(e), \dots, P(e''''), \neg P(e'''') \}$ & невыполнимо & 32 варианта
 \end{tabular}
 \end{frame}
 


### PR DESCRIPTION
Оценка not P(e'''') однозначно определяется, если известна оценка P(e''''), поэтому всего 2^5 = 32 варианта
Маркова Александра М3236